### PR TITLE
Added comparison of track length and video length

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -65,7 +65,7 @@ var YouTubePlugin = function (data) {
             var str = "No data.";
             
             getInfo(results, function(err, result, durationMs) {
-                console.log(result, durationMs);
+                
                 if (result.link && result.title) {
                     str = result.title + " : " + result.link;
                 }


### PR DESCRIPTION
Not the highest quality bit of code I've ever produced, but I hope you get the general idea. The code can be cleaned up a lot if we skip the part that returns the closest match if none is found.

The `youtube-info` plugin is pretty slow compared to `youtube-search`, but that's the only (first) way I could find to retrieve the video's duration.

Let me know if there is anything I can do to improve it!